### PR TITLE
Add circuit wire connectors to fi_* entities

### DIFF
--- a/prototypes/fission/fi_castor.lua
+++ b/prototypes/fission/fi_castor.lua
@@ -91,5 +91,15 @@ data:extend({
             idle_sound = { filename = "__base__/sound/idle1.ogg", volume = 0.3 },
             apparent_volume = 0.2,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation = 27, main_offset = util.by_pixel( 38.25,  23.25), shadow_offset = util.by_pixel( 38.25,  23.25), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.25,  23.25), shadow_offset = util.by_pixel( 38.25,  23.25), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.25,  23.25), shadow_offset = util.by_pixel( 38.25,  23.25), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.25,  23.25), shadow_offset = util.by_pixel( 38.25,  23.25), show_shadow = true },
+      }
+    )
     },
 })

--- a/prototypes/fission/fi_compound_machine.lua
+++ b/prototypes/fission/fi_compound_machine.lua
@@ -148,6 +148,16 @@ data:extend({
         sound = {filename = "__base__/sound/chemical-plant-3.ogg" },
         apparent_volume = 0.3,
       },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation =  0, main_offset = util.by_pixel( 28.875, -81.75), shadow_offset = util.by_pixel( 28.875, -81.75), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 28.875, -81.75), shadow_offset = util.by_pixel( 28.875, -81.75), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 28.875, -81.75), shadow_offset = util.by_pixel( 28.875, -81.75), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 28.875, -81.75), shadow_offset = util.by_pixel( 28.875, -81.75), show_shadow = true },
+      }
+    )
   },
 })
 

--- a/prototypes/fission/fi_crafter.lua
+++ b/prototypes/fission/fi_crafter.lua
@@ -108,5 +108,15 @@ data:extend({
             idle_sound = { filename = "__base__/sound/idle1.ogg", volume = 0.6 },
             apparent_volume = 0.7,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation = 27, main_offset = util.by_pixel( 38.75,  23.625), shadow_offset = util.by_pixel( 38.75,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.75,  23.625), shadow_offset = util.by_pixel( 38.75,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.75,  23.625), shadow_offset = util.by_pixel( 38.75,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.75,  23.625), shadow_offset = util.by_pixel( 38.75,  23.625), show_shadow = true },
+      }
+    )
     },
 })

--- a/prototypes/fission/fi_crusher.lua
+++ b/prototypes/fission/fi_crusher.lua
@@ -101,5 +101,15 @@ data:extend({
             sound = { filename ='__base__/sound/electric-mining-drill.ogg'},
             apparent_volume = 2.7,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation = 27, main_offset = util.by_pixel( 38.625,  23.625), shadow_offset = util.by_pixel( 38.625,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.625,  23.625), shadow_offset = util.by_pixel( 38.625,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.625,  23.625), shadow_offset = util.by_pixel( 38.625,  23.625), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.625,  23.625), shadow_offset = util.by_pixel( 38.625,  23.625), show_shadow = true },
+      }
+    )
     },
 })

--- a/prototypes/fission/fi_fiberer.lua
+++ b/prototypes/fission/fi_fiberer.lua
@@ -102,5 +102,15 @@ data:extend({
             idle_sound = { filename = "__base__/sound/idle1.ogg", volume = 0.6 },
             apparent_volume = 0.7,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation = 27, main_offset = util.by_pixel( 38.5,  23.5), shadow_offset = util.by_pixel( 38.5,  23.5), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.5,  23.5), shadow_offset = util.by_pixel( 38.5,  23.5), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.5,  23.5), shadow_offset = util.by_pixel( 38.5,  23.5), show_shadow = true },
+        { variation = 27, main_offset = util.by_pixel( 38.5,  23.5), shadow_offset = util.by_pixel( 38.5,  23.5), show_shadow = true },
+      }
+    )
     },
 })

--- a/prototypes/fission/fi_refinery.lua
+++ b/prototypes/fission/fi_refinery.lua
@@ -207,5 +207,15 @@ data:extend({
             sound = { filename ='__base__/sound/electric-mining-drill.ogg'},
             apparent_volume = 2.7,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_vector(
+      universal_connector_template, 
+      {
+        { variation =  0, main_offset = util.by_pixel( 31.125, -5.125), shadow_offset = util.by_pixel( 31.125, -5.125), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 31.125, -5.125), shadow_offset = util.by_pixel( 31.125, -5.125), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 31.125, -5.125), shadow_offset = util.by_pixel( 31.125, -5.125), show_shadow = true },
+        { variation =  0, main_offset = util.by_pixel( 31.125, -5.125), shadow_offset = util.by_pixel( 31.125, -5.125), show_shadow = true },
+      }
+    )
     },
 })

--- a/prototypes/fission/fi_robo.lua
+++ b/prototypes/fission/fi_robo.lua
@@ -59,7 +59,6 @@ data:extend({
         energy_usage = '4MW',
         charge_approach_distance = 2,
         charging_energy = '4MW',
-        recharge_minimum = '1MW',
         charging_station_count = 8, 
         construction_radius = 70,
         logistics_radius = 70,
@@ -123,55 +122,11 @@ data:extend({
 			scale = 1.5,
 			animation_speed = 0.5
         },
-
-        circuit_wire_connection_point = {
-            wire = {
-                copper = {0, 0},
-                green = {0, 0},
-                red = {0, 0}
-            },
-            shadow = {
-                copper = {0, 0},
-                green = {0, 0},
-                red = {0, 0}
-            }
-        },
-		circuit_connector_sprites = {
-            led_red = {
-                filename = "__248k-Redux__/ressources/64x64_empty.png",
-                width = 64,
-                height = 64,
-                shift = {0, 0},
-                intensity = 0.3,
-                size = 1
-            },
-            led_green = {
-                filename = "__248k-Redux__/ressources/64x64_empty.png",
-                width = 64,
-                height = 64,
-                shift = {0, 0},
-                intensity = 0.3,
-                size = 1
-            },
-            led_blue = {
-                filename = "__248k-Redux__/ressources/64x64_empty.png",
-                width = 64,
-                height = 64,
-                shift = {0, 0},
-                intensity = 0.3,
-                size = 1
-            },
-            led_light = {
-                filename = "__248k-Redux__/ressources/64x64_empty.png",
-                width = 64,
-                height = 64,
-                shift = {0, 0},
-                intensity = 0.3,
-                size = 1,
-                blend_mode = "additive",
-            },
-        },
-		circuit_wire_max_distance = 20,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_single(
+      universal_connector_template, 
+        { variation = 26, main_offset = util.by_pixel( 34.125, -23.25), shadow_offset = util.by_pixel( 34.125, -23.25), show_shadow = true }
+    )
     },
     --charger
     {
@@ -198,7 +153,6 @@ data:extend({
         energy_usage = '4MW',
         charge_approach_distance = 2,
         charging_energy = '12MW',
-        recharge_minimum = '1MW',
         charging_station_count = 12, 
         construction_radius = 1,
         logistics_radius = 1,
@@ -260,9 +214,5 @@ data:extend({
 			scale = 1.5,
 			animation_speed = 0.5
         }
-        
-
-        
-        
     },
 })

--- a/prototypes/fission/fi_solid_reactor.lua
+++ b/prototypes/fission/fi_solid_reactor.lua
@@ -95,5 +95,10 @@ data:extend({
             sound = { filename ='__base__/sound/nuclear-reactor-1.ogg'},
             apparent_volume = 2.5,
         },
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions.create_single(
+      universal_connector_template, 
+        { variation = 26, main_offset = util.by_pixel(-83.75,  11.875), shadow_offset = util.by_pixel(-83.75,  11.875), show_shadow = true }
+    )
     },
 })


### PR DESCRIPTION
All wire connections for the fi_* entities, the robo port is somehow drawing above the connector, I can't find a fix for it atm
<img width="941" height="553" alt="image" src="https://github.com/user-attachments/assets/b273f025-1d56-497d-9baa-cac844d63eba" />
